### PR TITLE
Fix testing pipeline issues

### DIFF
--- a/phpstan.jtl-shop-5.3.4.neon
+++ b/phpstan.jtl-shop-5.3.4.neon
@@ -7,7 +7,7 @@ parameters:
         - ./vendor
         - ./node_modules
     bootstrapFiles:
-        - shops/5.3.3/includes/vendor/autoload.php
-        - shops/5.3.3/includes/config.JTL-Shop.ini.php
-        - shops/5.3.3/includes/defines.php
-        - shops/5.3.3/includes/autoload.php
+        - shops/5.3.4/includes/vendor/autoload.php
+        - shops/5.3.4/includes/config.JTL-Shop.ini.php
+        - shops/5.3.4/includes/defines.php
+        - shops/5.3.4/includes/autoload.php


### PR DESCRIPTION
Update the build script to correctly handle whitespace in the ExsID tag removal, ensuring proper packaging.

Update phpstan configuration to use the correct JTL-Shop version for autoloading and configuration files.

Update plugin version.