### PR TITLE
Add support for JTL-Shop version 5.5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
             "phpstan analyse -c phpstan.jtl-shop-5.1.7.neon",
             "phpstan analyse -c phpstan.jtl-shop-5.2.6.neon",
             "phpstan analyse -c phpstan.jtl-shop-5.3.4.neon",
-            "phpstan analyse -c phpstan.jtl-shop-5.4.0.neon"
+            "phpstan analyse -c phpstan.jtl-shop-5.4.0.neon",
+            "phpstan analyse -c phpstan.jtl-shop-5.5.1.neon"
         ],
         "phpmd": "phpmd ./src,./Bootstrap.php text unusedcode",
         "phpcompat": "bash test_php_versions.sh",

--- a/fetch_shops.sh
+++ b/fetch_shops.sh
@@ -5,6 +5,7 @@ mkdir -p shops
 
 # List of shop versions
 VERSIONS=(
+    "5.5.1"
     "5.4.0"
     "5.3.4"
     "5.2.6"

--- a/info.xml
+++ b/info.xml
@@ -8,7 +8,7 @@
     <XMLVersion>101</XMLVersion>
     <MinShopVersion>5.1.2</MinShopVersion>
     <CreateDate>2021-03-24</CreateDate>
-    <Version>1.2.5</Version>
+    <Version>1.2.8</Version>
     <ExsID>f9cb7819-9dad-4a4f-8aea-fcca10d6b59c</ExsID>
     <Install>
         <FlushTags>CACHING_GROUP_TEMPLATE</FlushTags>

--- a/phpstan.jtl-shop-5.5.1.neon
+++ b/phpstan.jtl-shop-5.5.1.neon
@@ -1,0 +1,13 @@
+parameters:
+    level: 8
+    paths:
+        - ./
+    excludePaths:
+        - ./shops
+        - ./vendor
+        - ./node_modules
+    bootstrapFiles:
+        - shops/5.5.1/includes/vendor/autoload.php
+        - shops/5.5.1/includes/config.JTL-Shop.ini.php
+        - shops/5.5.1/includes/defines.php
+        - shops/5.5.1/includes/autoload.php


### PR DESCRIPTION
Add PHPStan configuration and fetch script entry for the new JTL-Shop version.

Update plugin version.